### PR TITLE
fix/only one repo being sent

### DIFF
--- a/frontend/src/app.jsx
+++ b/frontend/src/app.jsx
@@ -89,6 +89,7 @@ export function App() {
 
         const repoName = url.match(/\/([^/]+)\.git$/)[1];
 
+        // if(new_name == name) add({old_name: name, new_name:name})
         setMergedUrls((mergedUrls) => [
           ...mergedUrls,
           {


### PR DESCRIPTION
The issue with only one author being sent was related to regex which was wrongly executed.
- [x] https://github.com/maneike/codeStats/issues/95
- [x] Filtering out submitted repos 
