### PR TITLE
fix: merged repos sent incorrectly to api

### DIFF
--- a/frontend/src/components/UrlsToMergeList/UrlsToMergeList.jsx
+++ b/frontend/src/components/UrlsToMergeList/UrlsToMergeList.jsx
@@ -4,8 +4,6 @@ import DropdownSelect from "../DropdownSelect";
 import Ul from "../Ul";
 import Li from "../Li";
 
-import { regex } from "../../helpers/extractRepoNameFromUrl";
-
 const UrlsToMergeList = ({ repoUrlsToMerge, mergedUrls, setMergedUrls }) => {
   const repoNames = repoUrlsToMerge.map((repoUrl) => {
     const repoName = repoUrl.match(/\/([^/]+)\.git$/)[1];


### PR DESCRIPTION
- [x] Send merged repos correctly to `/url/` endpoint 

Before, when trying to merge two repos, there were 3 objects sent into `/url/` endpoint, instead of 2. Right now the request is sent correctly, however there are some problems with API. Should wait before merging.